### PR TITLE
add i386 build for installing on DS214play

### DIFF
--- a/2_create_project/INFO-e
+++ b/2_create_project/INFO-e
@@ -1,5 +1,5 @@
 package="minio"
-arch="armada370 armada375 armada38x armadaxp alpine/alpine4k comcerto2k monaco"
+arch="<ARCH>"
 version="<VERSION>"
 description="private cloud storage"
 support_url="https://minio.io/"

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,12 @@ GOARM = 7
 my_d = $(shell pwd -P)
 minio_src := go/src/github.com/minio/minio
 
-.PHONY: build
-build: minio_arm_7 pkg_7
+.PHONY: build i386 arm7
+build:
+	@echo "Usage: make init; make arm7|i386"
+
+arm7: minio_arm7 pkg_arm7
+i386: minio_i386 pkg_i386
 
 .PHONY: clean
 clean:
@@ -46,29 +50,42 @@ pkg_version := $(subst RELEASE.,,$(date_release))
 info:
 	@echo "$(last_release) $(pkg_version)"
 
-.PHONY: minio_arm_%
+.PHONY: minio minio_%
 _docker_cmd = docker run --rm -it -v $(my_d)/$(minio_src):/$(minio_src) -v $(my_d):/out --workdir=/$(minio_src)
 _docker_ctr = golang:stretch
-minio_arm_%: LDFLAGS=$(shell $(_docker_cmd) $(_docker_ctr) bash -c "go run buildscripts/gen-ldflags.go")
-minio_arm_%:
+minio_arm7: go_env=--env GOARCH=arm --env GOARM=7
+minio_arm7: pkg_arch=arm-7
+minio_arm7: minio
+minio_i386: go_env=--env GOARCH=386
+minio_i386: pkg_arch=i386
+minio_i386: minio
+
+minio: LDFLAGS=$(shell $(_docker_cmd) $(_docker_ctr) bash -c "go run buildscripts/gen-ldflags.go")
+minio:
 	@echo "Working on $(last_release)"
 	@echo "Cross-compiling in Docker, this will take a few minutes"
 	$(_docker_cmd) \
 		--env CGO_ENABLED=0 \
 		--env GOOS="linux" \
-		--env GOARCH=arm \
-		--env GOARM=$*\
+		--env GO111MODULE=on \
+		$(go_env) \
 		$(_docker_ctr) \
-		go build -tags kqeue --ldflags '$(LDFLAGS)' -o /out/minio-$(pkg_version)-linux-arm-$*
+		sh -c "go get ./... && go build -tags kqeue --ldflags '$(LDFLAGS)' -o /out/minio-$(pkg_version)-linux-$(pkg_arch)"
 
-.PHONY: pkg_%
-pkg_%:
-	sed -e "s/version=.*/version=\"$(pkg_version)\"/g" \
+.PHONY: pkg pkg_%
+pkg_arm7: pkg_arch=arm-7
+pkg_arm7: syno_arch=armada370 armada375 armada38x armadaxp alpine\/alpine4k comcerto2k monaco
+pkg_arm7: pkg
+pkg_i386: pkg_arch=i386
+pkg_i386: syno_arch="evansport"
+pkg_i386: pkg
+pkg:
+	sed -e "s/version=.*/version=\"$(pkg_version)\"/g;s/arch=.*/arch=\"$(syno_arch)\"/g" \
 		2_create_project/INFO-e > 2_create_project/INFO
 	mkdir -p 1_create_package/minio
-	cp minio-$(pkg_version)-*$* 1_create_package/minio/minio
+	cp minio-$(pkg_version)-linux-$(pkg_arch) 1_create_package/minio/minio
 	cd 1_create_package && \
 		tar cvfhz ../2_create_project/package.tgz *
 	cd 2_create_project && \
-		tar cvfz ../minio-$(pkg_version)-arm-7.spk --exclude=INFO.in *
+		tar cvfz ../minio-$(pkg_version)-$(pkg_arch).spk --exclude=INFO.in *
 	rm -f package.tgz

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ What this is
 ===
 
 Minio offers a wide-variety of features. This repo only exposes enough of Minio to get started. That is:
-* fetch and build Minio for the Synology ARM platform
+* fetch and build Minio for the Synology ARM or i386-platform
 * package Minio in a SPK format
-* Targets for ARM based Synology
+* Targets for ARM or i386-based Synology
 
 Minio has elected to support Synology NAS's through [Docker Containers](https://github.com/minio/minio/issues/4210). In my opinion, targeting Docker is the correct decision for Cloud-base storage. However, if you have a consumer-grade Synology NAS, using Docker is a non-starter: I hope that this side-project will help close the gap.
 
@@ -22,7 +22,7 @@ Here Be Dragons
 
 Removing the Minio installation from the NAS will result in your data being deleted.
 
-THIS ONLY WORKS FOR ARM-7 NAS's right now.
+THIS ONLY WORKS FOR ARM-7 or i386 NAS's right now.
 
 Due to the inclusion of Minio's Art Work, re-distribution of the SPK may violate their terms. Please see LICENSE-Artwork for more information..
 
@@ -45,7 +45,7 @@ Docker is used to as the build system and to manage dependencies, specifically:
 
 After cloning/forking this repo:
 * run `make init`. This step fetches the latest release of Minio and the icons.
-* run `make`. During this step, a docker container will cross compile Minio. It will take a bit.
+* run `make arm7` or `make i386`. During this step, a docker container will cross compile Minio. It will take a bit.
 * Go to your NAS's package manager
 * Click Manually uplaod
 * Follow the dialogs

--- a/arch.desc
+++ b/arch.desc
@@ -1,7 +1,7 @@
 # Maps Minio platforms to Synology arch values, see
 # https://developer.synology.com/developer-guide/appendix/index.html
 # https://github.com/SynologyOpenSource/pkgscripts-ng/blob/master/include/platforms
-386 x86
+386 x86 evansport
 amd64 cedarview bromolow denverton apollolake avoton braswell grantley broadwell dockerx64 kvmx64 x64 
 arm-5 88f6281 88f6282
 arm-7 armada370 armada375 armada38x armadaxp alpine/alpine4k comcerto2k monaco


### PR DESCRIPTION
Thanks for you code - I successfully used it to install Minio on DS214play (yes, no Docker support). Contributing back my changes; may be not the most elegant way, but it works well.