### PR TITLE
Adding amd64 to support DS418

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 **/.DS_Store
 1_create_package/minio/minio
 2_create_project/INFO
+2_create_project/*.PNG
 go/**
-minio*linux*arm
+minio*linux*arm*
+minio*.spk

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@ minio_src := go/src/github.com/minio/minio
 
 .PHONY: build i386 arm7
 build:
-	@echo "Usage: make init; make arm7|i386"
+	@echo "Usage: make init; make arm7|i386|arm64"
 
 arm7: minio_arm7 pkg_arm7
+arm64: minio_arm64 pkg_arm64
 i386: minio_i386 pkg_i386
 
 .PHONY: clean
@@ -42,7 +43,7 @@ artwork:
 			cp /src/1_create_package/ui/minio-256.png /src/2_create_project/PACKAGE_ICON.PNG; '
 
 
-last_release := $(shell cd $(minio_src) 2>&1 /dev/null && git tag | sort -r | gawk '/RELEASE/{print$$1; exit;}' || echo unknown)
+last_release := $(shell cd $(minio_src) && git tag | sort -r | gawk '/RELEASE/{print$$1; exit;}' || echo unknown)
 date_release := $(shell echo $(last_release) | awk -F'T' '{gsub("RELEASE-", "", $$1); gsub("-",".", $$1); print$$1}')
 pkg_version := $(subst RELEASE.,,$(date_release))
 
@@ -56,6 +57,9 @@ _docker_ctr = golang:stretch
 minio_arm7: go_env=--env GOARCH=arm --env GOARM=7
 minio_arm7: pkg_arch=arm-7
 minio_arm7: minio
+minio_arm64: go_env=--env GOARCH=arm64 
+minio_arm64: pkg_arch=arm64
+minio_arm64: minio
 minio_i386: go_env=--env GOARCH=386
 minio_i386: pkg_arch=i386
 minio_i386: minio
@@ -76,6 +80,9 @@ minio:
 pkg_arm7: pkg_arch=arm-7
 pkg_arm7: syno_arch=armada370 armada375 armada38x armadaxp alpine\/alpine4k comcerto2k monaco
 pkg_arm7: pkg
+pkg_arm64: pkg_arch=arm64
+pkg_arm64: syno_arch=rtd1296
+pkg_arm64: pkg
 pkg_i386: pkg_arch=i386
 pkg_i386: syno_arch="evansport"
 pkg_i386: pkg

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Here Be Dragons
 
 Removing the Minio installation from the NAS will result in your data being deleted.
 
-THIS ONLY WORKS FOR ARM-7 or i386 NAS's right now.
+THIS ONLY WORKS FOR ARM-7/ARM64 or i386 NAS's right now.
 
 Due to the inclusion of Minio's Art Work, re-distribution of the SPK may violate their terms. Please see LICENSE-Artwork for more information..
 
@@ -37,7 +37,7 @@ Getting Started
 You will need:
 * Docker
 * Git
-* A Synology NAS
+* A Synology NAS based on one of the chipsets in [arch.desc](arch.desc) file
 
 Docker is used to as the build system and to manage dependencies, specifically:
 * Artwork is fetched remotely. This requires tooling to get the artwork, unzip to extract it and ImageMagick to transform the icon sizes.
@@ -45,10 +45,11 @@ Docker is used to as the build system and to manage dependencies, specifically:
 
 After cloning/forking this repo:
 * run `make init`. This step fetches the latest release of Minio and the icons.
-* run `make arm7` or `make i386`. During this step, a docker container will cross compile Minio. It will take a bit.
+* run `make arm7` or `make arm64` or `make i386`. During this step, a docker container will cross compile Minio. It will take a bit.
 * Go to your NAS's package manager
 * Click Manually uplaod
 * Follow the dialogs
+* Take care to choose a good `ADMIN_KEY` and `SECRET_KEY` 
 * Login at `http://<NAS IP>:<port>` where `<port>` was the one you selected in the dialogs.
 
 Pull-Requests Accepted


### PR DESCRIPTION
DS418 uses an aarch64 SoC that needs a different build target for a reasonable spk file.  This PR updates the Makefile to build that spk and the Readme to document it.  It also adds some entries to the .gitignore that helped keep my build directory clean.