### PR TITLE
Rename ADMIN_KEY to ACCESS_KEY and README additions

### DIFF
--- a/2_create_project/WIZARD_UIFILES/install_uifile
+++ b/2_create_project/WIZARD_UIFILES/install_uifile
@@ -18,7 +18,7 @@
           },
           {
             "key": "MINIO_ACCESS_KEY",
-            "desc": "the MINIO_ADMIN_KEY value",
+            "desc": "the MINIO_ACCESS_KEY value",
             "defaultVaule": "admin",
             "validator": {
               "allowBlank": false,

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Getting Started
 ===
 
 You will need:
+* Make
+* gawk
 * Docker
 * Git
 * A Synology NAS based on one of the chipsets in [arch.desc](arch.desc) file
@@ -46,10 +48,10 @@ Docker is used to as the build system and to manage dependencies, specifically:
 After cloning/forking this repo:
 * run `make init`. This step fetches the latest release of Minio and the icons.
 * run `make arm7` or `make arm64` or `make i386`. During this step, a docker container will cross compile Minio. It will take a bit.
-* Go to your NAS's package manager
-* Click Manually uplaod
+* Go to your NAS's package manager. This should be Synology's "Package Center".
+* Click `Manual Install`
 * Follow the dialogs
-* Take care to choose a good `ADMIN_KEY` and `SECRET_KEY` 
+* Take care to choose a good `ACCESS_KEY` and `SECRET_KEY` 
 * Login at `http://<NAS IP>:<port>` where `<port>` was the one you selected in the dialogs.
 
 Pull-Requests Accepted


### PR DESCRIPTION
Hi!
Here's a few things I noticed while compiling and installing this.
* MINIO_ADMIN_KEY doesn't show up on Google so it left me terribly confused. After digging through the code I saw this is actually ACCESS_KEY. It's also called that in the beginning of the README, so I cleaned up all occurences of ADMIN_KEY that I could find.
* Added two packages I had to install to get the compliation to work. For clarification: make is not included by default in Ubuntu Server. For Ubuntu Desktop, neither gawk or make is included by default.
* Minor edits to the installation guide.

Finding this GIT repo really made my day. Great work! 🥇 