### PR TITLE
fix(Makefile): disable git unsafe repository check when generating LD…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ minio_i386: go_env=--env GOARCH=386
 minio_i386: pkg_arch=i386
 minio_i386: minio
 
-minio: LDFLAGS=$(shell $(_docker_cmd) $(_docker_ctr) bash -c "go run buildscripts/gen-ldflags.go")
+minio: LDFLAGS=$(shell $(_docker_cmd) $(_docker_ctr) bash -c "git config --global --add safe.directory '*' && go run buildscripts/gen-ldflags.go")
 minio:
 	@echo "Working on $(last_release)"
 	@echo "Cross-compiling in Docker, this will take a few minutes"


### PR DESCRIPTION
…FLAGS

Recent versions of Git added a feature to check ownership of the repository. This caused `buildscripts/gen-ldflags.go` to fail with exit status 128 due to the image being run as uid 0 and the minio repository mounted into the container being owned by a different UID.

Other possible fixes could include:
- chowning the repo to uid 0, which would be obnoxious to say the least
- adding a user to the image with ID matching the UID owning the minio repo

FWIW, `go-gitea` appears to have gone with the same approach (ref: https://github.com/go-gitea/gitea/blob/c86d033a3ec0514efcd9524d03dce1b6551e487f/snap/snapcraft.yaml#L53)