### PR TITLE
chore: update to go1.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ info:
 
 .PHONY: minio minio_%
 _docker_cmd = docker run --rm -it -v $(my_d)/$(minio_src):/$(minio_src) -v $(my_d):/out --workdir=/$(minio_src)
-_docker_ctr = golang:stretch
+_docker_ctr = golang:1.21
 minio_arm7: go_env=--env GOARCH=arm --env GOARM=7
 minio_arm7: pkg_arch=arm-7
 minio_arm7: minio

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ minio:
 		--env GO111MODULE=on \
 		$(go_env) \
 		$(_docker_ctr) \
-		sh -c "go get ./... && go build -tags kqeue --ldflags '$(LDFLAGS)' -o /out/minio-$(pkg_version)-linux-$(pkg_arch)"
+		sh -c "go get ./... && go build -buildvcs=false -tags kqeue --ldflags '$(LDFLAGS)' -o /out/minio-$(pkg_version)-linux-$(pkg_arch)"
 
 .PHONY: pkg pkg_%
 pkg_arm7: pkg_arch=arm-7


### PR DESCRIPTION
This PR makes the following changes:

- Updates builder image to `golang:1.21`as the most recent version of minio (tested with RELEASE.2024-02-17T01-15-57Z) requires it:

  ```
  github.com/minio/minio/cmd imports
	  github.com/minio/kes-go imports
	  slices: package slices is not in GOROOT (/usr/local/go/src/slices)
  note: imported by a module that requires go 1.21
  ```

- Disables VCS stamping when building the binary by setting `-buildvcs=false`. From the references to https://github.com/golang/go/issues/49004, this seems to be the most common workaround.